### PR TITLE
Add Kubernetes resource manifests

### DIFF
--- a/resources/alertmanager/alertmanager-values.yaml
+++ b/resources/alertmanager/alertmanager-values.yaml
@@ -1,0 +1,14 @@
+alertmanager:
+  config:
+    route:
+      receiver: n8n-webhook
+      group_by: ["alertname","namespace"]
+      group_wait: 10s
+      group_interval: 2m
+      repeat_interval: 12h
+    receivers:
+      - name: n8n-webhook
+        webhook_configs:
+          - url: https://n8n.example.com/webhook/alertmanager
+            send_resolved: true
+            max_alerts: 20

--- a/resources/alerts/demo-alerts.yaml
+++ b/resources/alerts/demo-alerts.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: demo-alerts
+  namespace: monitoring
+  labels:
+    release: monitoring
+spec:
+  groups:
+    - name: demo.rules
+      rules:
+        - alert: DemoCrashLooping
+          expr: kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace="demo"} > 0
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pod is crash looping in {{ $labels.namespace }}"
+            description: "Pod {{ $labels.pod }} (container {{ $labels.container }}) has been CrashLoopBackOff for >2m."
+        - alert: DemoPodNotReady
+          expr: kube_pod_status_ready{condition="true", namespace="demo"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pod not ready in {{ $labels.namespace }}"
+            description: "Pod {{ $labels.pod }} has not been Ready for >5m."

--- a/resources/demo/demo-app.yaml
+++ b/resources/demo/demo-app.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fail-app
+  namespace: demo
+  labels: { app: fail-app }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: fail-app }
+  template:
+    metadata:
+      labels: { app: fail-app }
+    spec:
+      containers:
+        - name: boom
+          image: alpine:3.20
+          command: ["/bin/sh","-c"]
+          args: ["echo starting && sleep 5 && exit 1"]
+          # probes aren't necessary; the crash itself will be visible to kube-state-metrics

--- a/resources/n8n/n8n.yaml
+++ b/resources/n8n/n8n.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: n8n-data
+  namespace: automation
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: n8n
+  namespace: automation
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: n8n }
+  template:
+    metadata:
+      labels: { app: n8n }
+    spec:
+      serviceAccountName: n8n-sa
+      containers:
+        - name: n8n
+          image: myregistry.example.com/tools/n8n-kubectl-jq:1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: N8N_HOST
+              value: "n8n.example.com"
+            - name: N8N_PROTOCOL
+              value: "https"
+            - name: N8N_PORT
+              value: "5678"
+            - name: WEBHOOK_URL
+              value: "https://n8n.example.com/"
+            # Optional: turn on basic auth to protect editor
+            # - name: N8N_BASIC_AUTH_ACTIVE
+            #   value: "true"
+            # - name: N8N_BASIC_AUTH_USER
+            #   valueFrom: {secretKeyRef: {name: n8n-auth, key: user}}
+            # - name: N8N_BASIC_AUTH_PASSWORD
+            #   valueFrom: {secretKeyRef: {name: n8n-auth, key: pass}}
+          ports:
+            - containerPort: 5678
+          volumeMounts:
+            - name: data
+              mountPath: /home/node/.n8n
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: n8n-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: n8n
+  namespace: automation
+spec:
+  selector: { app: n8n }
+  ports:
+    - name: http
+      port: 80
+      targetPort: 5678
+---
+# Optional: if you have an ingress controller + DNS/SSL ready
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: n8n
+  namespace: automation
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    # cert-manager:
+    # cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  rules:
+    - host: n8n.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: n8n
+                port:
+                  number: 80
+  # tls:
+  #   - hosts: ["n8n.example.com"]
+  #     secretName: n8n-tls

--- a/resources/rbac/rbac-n8n.yaml
+++ b/resources/rbac/rbac-n8n.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: automation
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: n8n-sa
+  namespace: automation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: n8n-readonly
+rules:
+  - apiGroups: [""]
+    resources: ["pods","services","endpoints","configmaps","events","namespaces","nodes"]
+    verbs: ["get","list","watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments","replicasets","statefulsets","daemonsets"]
+    verbs: ["get","list","watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs","cronjobs"]
+    verbs: ["get","list","watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses","networkpolicies"]
+    verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: n8n-readonly-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: n8n-readonly
+subjects:
+  - kind: ServiceAccount
+    name: n8n-sa
+    namespace: automation


### PR DESCRIPTION
## Summary
- add RBAC for n8n read-only access
- provide n8n deployment, service, and ingress definitions
- include demo app, alert rules, and alertmanager webhook config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86e3aa4f8832fb43b7b3ace5e6d00